### PR TITLE
Fix node id not starting at 0

### DIFF
--- a/algo/grid.ts
+++ b/algo/grid.ts
@@ -6,6 +6,7 @@ import { Node, NodeType } from "./models/Node.js";
 export const grid = makeGrid();
 
 export function makeGrid(gridSize: number = 10): Grid {
+  Node._id = 0;
   const grid: Grid = new Array(gridSize);
   for (let x = 0; x < gridSize; x++) {
     grid[x] = new Array(gridSize);

--- a/algo/models/Node.ts
+++ b/algo/models/Node.ts
@@ -15,8 +15,8 @@ export class Node {
   distEdges: Edge[] = [];
   incomingDistEdges: Node[] = [];
 
-  constructor(x: number, y: number, type: NodeType, mue?: number) {
-    this.id = Node._id++;
+  constructor(x: number, y: number, type: NodeType, mue?: number, id?: number) {
+    this.id = id ?? Node._id++;
     this.type = type;
     this.x = x;
     this.y = y;

--- a/client/saveService.ts
+++ b/client/saveService.ts
@@ -126,7 +126,7 @@ function recreateNodeCircularReference(jsonSafeGrid: NodeJSON[][]): Grid {
 
     //Recreate nodes
     jsonSafeGrid.forEach((col, x) => col.forEach((space, y) => {
-        newGrid[x][y] = new Node(x, y, jsonSafeGrid[x][y].type, jsonSafeGrid[x][y].mue)
+        newGrid[x][y] = new Node(x, y, jsonSafeGrid[x][y].type, jsonSafeGrid[x][y].mue, jsonSafeGrid[x][y].id)
     }))
 
     //Recreate edges and disturbances


### PR DESCRIPTION
I've done so the default grid always starts generating from id = 0, but resetting the static field. This is done to fix the resetGrid button incrementing the IDs by 100 each time. Also, the Node object takes its id as an optional parameter in its constructor. If it's not set, it uses the static id field.