### PR TITLE
#62 bugfix diagonal edges

### DIFF
--- a/client/index.ts
+++ b/client/index.ts
@@ -201,7 +201,6 @@ function drawSquareInGrid(
     removeEdgesJumpingDiagonalWater(grid[col][row])
   } else if (grid[col][row].type == "water") {
     recreateDiagonalEdges(grid[col][row])
-    console.log(grid)
   }
 
   const ctx = canvas.getContext("2d")!;


### PR DESCRIPTION
This PR closes #62 

What I've done:
When a water cell is placed it detects if there are other diagonally placed water cells. If there are, it deletes the edges jumping between diagonally. See picture below. The red arrows show what edges are deleted (not visualized in the actual UI 😉)

Be aware that https://github.com/JonasStjerne/P7/pull/61 displays diagonal edges, which will make a "wall" appear between the water. 

![image](https://github.com/JonasStjerne/P7/assets/73853586/f5c8ae1b-2ceb-4411-bf41-00e0c6b099fa)
